### PR TITLE
fix: correct scheduler parameter name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ interface SDAPIPayload {
   height: number;
   cfg_scale: number;
   sampler_name: string;
-  scheduler_name: string;
+  scheduler: string;
   seed: number;
   n_iter: number;
   restore_faces?: boolean;
@@ -268,7 +268,7 @@ class ImageGenServer {
               seed: args.seed ?? -1,
               n_iter: args.batch_size || 1,
               distilled_cfg_scale: args.distilled_cfg_scale || 3.5,
-              scheduler_name: args.scheduler_name || 'Simple',
+              scheduler: args.scheduler_name || 'Simple',
               tiling: !!args.tiling,
               restore_faces: !!args.restore_faces
             };


### PR DESCRIPTION
## Problem
The current implementation uses `scheduler_name` as the parameter name when calling the Stable Diffusion WebUI API, but the API actually expects `scheduler`. This causes scheduler settings (like Karras, Uniform, etc.) to be ignored, and the API falls back to its default scheduler.

webui implementation checking the "scheduler" variable on the request https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/api/api.py#L441

## Solution
- Changed `scheduler_name` to `scheduler`
- Updated the payload creation to use the correct parameter name

## Testing
- Verified that scheduler settings are now properly applied
- Tested with different scheduler values (Karras, Uniform) and confirmed they work correctly
- Build passes without errors

## Impact
This fix ensures that users can properly control the noise scheduling algorithm used during image generation.