### PR TITLE
fix: convert resize_mode enum to string type to resolve API validatio…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,8 +210,8 @@ class ImageGenServer {
                 description: 'Array of image file paths to upscale'
               },
               resize_mode: {
-                type: 'number',
-                enum: [0, 1],
+                type: 'string',
+                enum: ['0', '1'],
                 description: '0 for multiplier mode (default), 1 for dimension mode'
               },
               upscaling_resize: {
@@ -337,8 +337,11 @@ class ImageGenServer {
               };
             }));
 
+            // Convert resize_mode to number if present, otherwise use default
+            const resizeModeNum = args.resize_mode !== undefined ? Number(args.resize_mode) : SD_RESIZE_MODE;
+
             const payload: UpscaleImagePayload = {
-              resize_mode: args.resize_mode ?? SD_RESIZE_MODE,
+              resize_mode: resizeModeNum,
               show_extras_results: true,
               gfpgan_visibility: 0,
               codeformer_visibility: 0,
@@ -441,10 +444,9 @@ function isUpscaleImagesArgs(value: unknown): value is UpscaleImagesArgs {
     return false;
   }
 
-  // Validate optional numeric fields
+  // Validate optional resize_mode as string '0' or '1'
   if (v.resize_mode !== undefined) {
-    const mode = Number(v.resize_mode);
-    if (isNaN(mode) || ![0, 1].includes(mode)) return false;
+    if (typeof v.resize_mode !== 'string' || !['0', '1'].includes(v.resize_mode)) return false;
   }
 
   if (v.upscaling_resize !== undefined) {


### PR DESCRIPTION
…n error



## Error details: 

```
✕ [API Error: [{
    "error": {
      "code": 400,
      "message": "Invalid value at 
  'request.tools[0].function_declarations[15].parameters.properties[1].value.enum[0]' (TYPE_STRING), 
  0\nInvalid value at 
  'request.tools[0].function_declarations[15].parameters.properties[1].value.enum[1]' (TYPE_STRING), 
  1",
      "errors": [
        {
          "message": "Invalid value at 
  'request.tools[0].function_declarations[15].parameters.properties[1].value.enum[0]' (TYPE_STRING), 
  0\nInvalid value at 
  'request.tools[0].function_declarations[15].parameters.properties[1].value.enum[1]' (TYPE_STRING), 
  1",
          "reason": "invalid"
        }
      ],
      "status": "INVALID_ARGUMENT",
      "details": [
        {
          "@type": "type.googleapis.com/google.rpc.BadRequest",
          "fieldViolations": [
            {
              "field": 
  "request.tools[0].function_declarations[15].parameters.properties[1].value.enum[0]",
              "description": "Invalid value at 
  'request.tools[0].function_declarations[15].parameters.properties[1].value.enum[0]' (TYPE_STRING), 
  0"
            },
            {
              "field": 
  "request.tools[0].function_declarations[15].parameters.properties[1].value.enum[1]",
              "description": "Invalid value at 
  'request.tools[0].function_declarations[15].parameters.properties[1].value.enum[1]' (TYPE_STRING), 
  1"
            }
          ]
        }
      ]
    }
  }
  ]]
```


## Root Cause
The `resize_mode` parameter was defined with `type: 'number'` and `enum: [0, 1]`, but some APIs (particularly those expecting function declarations for LLMs or Google APIs) require enum values to be strings, not numbers.

## Solution
- Changed `resize_mode` property type from `'number'` to `'string'`
- Updated enum values from `[0, 1]` to `['0', '1']`
- Modified type validation in `isUpscaleImagesArgs()` to accept string values
- Updated the payload construction to convert string values to numbers before sending to the Stable Diffusion API

## Changes Made
- `src/index.ts`: Updated schema definition and type validation logic
